### PR TITLE
Refine dashboard visuals

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -167,7 +167,7 @@
         <div class="card p-3 h-100">
             <div class="kpi-title text-uppercase mb-2">Non-compliant Releases (48h)</div>
             <div class="table-responsive">
-                <table class="table table-striped table-hover table-sm align-middle">
+                <table class="table table-modern table-hover align-middle">
                     <thead>
                         <tr>
                             <th>Date/Time</th>
@@ -212,7 +212,7 @@
         <div class="card p-3 h-100">
             <div class="kpi-title text-uppercase mb-2">Upcoming Releases (24–48h)</div>
             <div class="table-responsive">
-                <table class="table table-striped table-hover table-sm align-middle">
+                <table class="table table-modern table-hover align-middle">
                     <thead>
                         <tr>
                             <th>Schedule</th>

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -31,6 +31,11 @@ body {
     box-shadow: var(--shadow-card);
 }
 
+.kpi-card {
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    box-shadow: 0 2px 4px rgba(15,23,42,0.12);
+}
+
 .kpi-card .sparkline {
     width: 60px;
     height: 24px;
@@ -110,6 +115,37 @@ body {
     background: var(--card);
     z-index: 1;
     font-weight: 600;
+}
+
+.table-modern {
+    border-collapse: separate;
+    border-spacing: 0 0.5rem;
+}
+
+.table-modern thead th {
+    border-bottom: none;
+    color: var(--ink-600);
+    font-size: .75rem;
+    text-transform: uppercase;
+}
+
+.table-modern tbody tr {
+    background: var(--card);
+    box-shadow: var(--shadow-card);
+}
+
+.table-modern tbody td:first-child {
+    border-top-left-radius: var(--radius-xl);
+    border-bottom-left-radius: var(--radius-xl);
+}
+
+.table-modern tbody td:last-child {
+    border-top-right-radius: var(--radius-xl);
+    border-bottom-right-radius: var(--radius-xl);
+}
+
+.table-modern tbody tr td {
+    border-top: none;
 }
 
 .table-striped tbody tr:nth-of-type(odd) {

--- a/wwwroot/js/amchartsInterop.js
+++ b/wwwroot/js/amchartsInterop.js
@@ -88,10 +88,16 @@ window.amchartsInterop = (function () {
     function createComplianceByStream(divId, data) {
         if (!ensureLibs()) return;
         const root = newRoot(divId);
-        const chart = root.container.children.push(am5xy.XYChart.new(root, { layout: root.verticalLayout, paddingTop: 10, paddingRight: 10, paddingBottom: 10, paddingLeft: 10 }));
+        root.container.setAll({ layout: root.verticalLayout, paddingTop: 20, paddingRight: 20, paddingBottom: 20, paddingLeft: 20 });
+
+        const chart = root.container.children.push(am5xy.XYChart.new(root, { layout: root.verticalLayout }));
+        chart.setAll({ centerX: am5.p50, x: am5.p50 });
+
+        const xRenderer = am5xy.AxisRendererX.new(root, { minGridDistance: 20 });
+        xRenderer.labels.template.setAll({ fontSize: 12 });
         const xAxis = chart.xAxes.push(am5xy.CategoryAxis.new(root, {
             categoryField: "stream",
-            renderer: am5xy.AxisRendererX.new(root, { minGridDistance: 20 })
+            renderer: xRenderer
         }));
         const yAxis = chart.yAxes.push(am5xy.ValueAxis.new(root, { renderer: am5xy.AxisRendererY.new(root, {}) }));
 
@@ -128,7 +134,7 @@ window.amchartsInterop = (function () {
             marginTop: 10,
             layout: root.horizontalLayout
         }));
-        legend.labels.template.setAll({ oversizedBehavior: 'wrap' });
+        legend.labels.template.setAll({ oversizedBehavior: 'wrap', fontSize: 12 });
         legend.data.setAll([s1, s2]);
 
         xAxis.data.setAll(data);
@@ -139,13 +145,17 @@ window.amchartsInterop = (function () {
     function createPerformanceChart(divId, data, metric) {
         if (!ensureLibs()) return;
         const root = newRoot(divId);
-        const chart = root.container.children.push(am5xy.XYChart.new(root, { paddingTop: 10, paddingRight: 10, paddingBottom: 10, paddingLeft: 10, layout: root.verticalLayout }));
+        root.container.setAll({ layout: root.verticalLayout, paddingTop: 20, paddingRight: 20, paddingBottom: 20, paddingLeft: 20 });
+
+        const chart = root.container.children.push(am5xy.XYChart.new(root, { layout: root.verticalLayout }));
+        chart.setAll({ centerX: am5.p50, x: am5.p50 });
 
         const xRenderer = am5xy.AxisRendererX.new(root, { minGridDistance: 80 });
         xRenderer.labels.template.setAll({
             rotation: -45,
             centerY: am5.p50,
-            centerX: am5.p100
+            centerX: am5.p100,
+            fontSize: 12
         });
 
         const xAxis = chart.xAxes.push(am5xy.DateAxis.new(root, {
@@ -180,7 +190,7 @@ window.amchartsInterop = (function () {
             marginTop: 10,
             layout: root.horizontalLayout
         }));
-        legend.labels.template.setAll({ oversizedBehavior: 'wrap' });
+        legend.labels.template.setAll({ oversizedBehavior: 'wrap', fontSize: 12 });
         legend.data.setAll([line, cols]);
 
         const parsed = data.map(d => ({ ...d, date: new Date(d.date).getTime() }));
@@ -191,8 +201,9 @@ window.amchartsInterop = (function () {
     function createViolationsDonut(divId, data) {
         if (!ensureLibs()) return;
         const root = newRoot(divId);
+        root.container.setAll({ layout: root.verticalLayout, paddingTop: 20, paddingRight: 20, paddingBottom: 20, paddingLeft: 20 });
         const chart = root.container.children.push(
-            am5percent.PieChart.new(root, { innerRadius: am5.percent(60), paddingTop: 10, paddingRight: 10, paddingBottom: 10, paddingLeft: 10 })
+            am5percent.PieChart.new(root, { innerRadius: am5.percent(60) })
         );
         const series = chart.series.push(
             am5percent.PieSeries.new(root, { valueField: 'count', categoryField: 'type' })
@@ -217,7 +228,7 @@ window.amchartsInterop = (function () {
             marginTop: 10,
             layout: am5.GridLayout.new(root, { maxColumns: 2 })
         }));
-        legend.labels.template.setAll({ oversizedBehavior: 'wrap' });
+        legend.labels.template.setAll({ oversizedBehavior: 'wrap', fontSize: 12 });
         legend.data.setAll(series.dataItems);
     }
 


### PR DESCRIPTION
## Summary
- Center and pad key charts while shrinking axis and legend text for clarity
- Tidy Share by Violations legend and shrink its font to avoid overlap
- Restyle tables and KPI cards with modern borders and shadows for a more polished look

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a9f39f0f348323b4960abf55028187