### PR TITLE
Handle missing amCharts gauge module

### DIFF
--- a/wwwroot/js/amchartsInterop.js
+++ b/wwwroot/js/amchartsInterop.js
@@ -59,9 +59,14 @@ window.amchartsInterop = (function () {
 
     function createGauge(divId, value, max) {
         if (!ensureLibs()) return;
+        if (!am5radar || (!am5radar.GaugeChart && !am5radar.RadarChart)) {
+            console.error("amCharts gauge module not loaded. Check CDN tags in index.html.");
+            return;
+        }
         const root = newRoot(divId);
+        const GaugeChartClass = am5radar.GaugeChart || am5radar.RadarChart;
         const chart = root.container.children.push(
-            am5radar.GaugeChart.new(root, { startAngle: 180, endAngle: 360 })
+            GaugeChartClass.new(root, { startAngle: 180, endAngle: 360 })
         );
         const axisRenderer = am5radar.AxisRendererCircular.new(root, { innerRadius: -20 });
         axisRenderer.grid.template.set('visible', false);


### PR DESCRIPTION
## Summary
- prevent runtime errors when amCharts gauge module isn't available by falling back to RadarChart and logging a console message

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68a9ff77ee948323bc0330aab5b3a003