### PR TITLE
Avoid crash when gauge chart module missing

### DIFF
--- a/wwwroot/js/amchartsInterop.js
+++ b/wwwroot/js/amchartsInterop.js
@@ -83,7 +83,9 @@ window.amchartsInterop = (function () {
             range.get('axisFill').setAll({ visible: true, fillOpacity: 1, fill: am5.color(r.color) });
         });
 
-        const hand = chart.hands.push(am5radar.ClockHand.new(root, { pinRadius: 0, radius: am5.percent(90), bottomWidth: 10 }));
+        const hand = am5radar.ClockHand.new(root, { pinRadius: 0, radius: am5.percent(90), bottomWidth: 10 });
+        const handContainer = chart.hands || chart.children;
+        handContainer.push(hand);
         hand.axis = xAxis;
         hand.set('value', value);
 


### PR DESCRIPTION
## Summary
- Guard against missing `chart.hands` when creating gauges so the dashboard doesn't throw JS errors if the gauge module isn't loaded

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68aa03025614832384f4e37adf77dee0