### PR TITLE
Fix KPI cards and resize violations donut legend

### DIFF
--- a/wwwroot/js/amchartsInterop.js
+++ b/wwwroot/js/amchartsInterop.js
@@ -21,6 +21,7 @@ window.amchartsInterop = (function () {
         const root = am5.Root.new(divId);
         root.setThemes([am5themes_Animated.new(root)]);
         root.dom.style.overflow = 'hidden';
+        root.dom.classList.remove('skeleton');
         const isDark = document.body.classList.contains('theme-dark');
         root.interfaceColors.set('text', am5.color(isDark ? 0xf8fafc : 0x0f172a));
         root.interfaceColors.set('grid', am5.color(isDark ? 0x475569 : 0x94a3b8));
@@ -55,6 +56,8 @@ window.amchartsInterop = (function () {
         series.strokes.template.setAll({ strokeWidth: 2 });
         series.fills.template.setAll({ fillOpacity: 0.2 });
         series.data.setAll(data.map((v, i) => ({ i, v })));
+        series.appear(0, 0);
+        chart.appear(0, 0);
     }
 
     function createGauge(divId, value, max) {
@@ -242,9 +245,9 @@ window.amchartsInterop = (function () {
     function createViolationsDonut(divId, data) {
         if (!ensureLibs()) return;
         const root = newRoot(divId);
-        root.container.setAll({ layout: root.verticalLayout, paddingTop: 20, paddingRight: 20, paddingBottom: 20, paddingLeft: 20 });
+        root.container.setAll({ layout: root.horizontalLayout, paddingTop: 20, paddingRight: 20, paddingBottom: 20, paddingLeft: 20 });
         const chart = root.container.children.push(
-            am5percent.PieChart.new(root, { innerRadius: am5.percent(60), height: am5.percent(70) })
+            am5percent.PieChart.new(root, { innerRadius: am5.percent(60), width: am5.percent(60) })
         );
         const series = chart.series.push(
             am5percent.PieSeries.new(root, { valueField: 'count', categoryField: 'type' })
@@ -264,13 +267,16 @@ window.amchartsInterop = (function () {
             })
         );
         const legend = root.container.children.push(am5.Legend.new(root, {
-            centerX: am5.percent(50),
-            x: am5.percent(50),
-            marginTop: 10,
-            layout: am5.GridLayout.new(root, { maxColumns: 2 })
+            marginLeft: 20,
+            centerY: am5.percent(50),
+            y: am5.percent(50),
+            width: am5.percent(40),
+            layout: root.verticalLayout
         }));
         legend.labels.template.setAll({ oversizedBehavior: 'wrap', fontSize: 12 });
         legend.data.setAll(series.dataItems);
+        series.appear(0, 0);
+        chart.appear(0, 0);
     }
 
     function createViolationsBar(divId, data) {


### PR DESCRIPTION
## Summary
- Remove skeleton placeholder when initializing charts
- Ensure sparklines render by triggering animations
- Resize violations donut so legend sits to the side

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68aa04df63f083239df843a9b089e19e