### PR TITLE
Fix amCharts gauge loading and center dashboard cards

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -56,13 +56,13 @@
 @* region KPI Tiles *@
 <div class="row g-3 mb-4">
     <div class="col-12 col-lg-6">
-        <div class="card kpi-card p-3 h-100">
+        <div class="card kpi-card p-3 h-100 text-center">
             <div class="kpi-title mb-2">Org Compliance</div>
             <div id="gaugeCompliance" class="chart" style="height:180px"></div>
         </div>
     </div>
     <div class="col-12 col-lg-6">
-        <div class="card kpi-card p-3 h-100">
+        <div class="card kpi-card p-3 h-100 text-center">
             <div class="kpi-title mb-2">CFR</div>
             <div id="gaugeCfr" class="chart" style="height:180px"></div>
         </div>
@@ -71,50 +71,34 @@
 
 <div class="row g-3 mb-4">
     <div class="col-6 col-md-3">
-        <div class="card kpi-card p-3 h-100">
-            <div class="d-flex justify-content-between">
-                <div>
-                    <div class="kpi-title">Deployments</div>
-                    <div class="kpi-value">@DataStore.Kpis.DeploymentsToday</div>
-                </div>
-                <div id="sparkDeploys" class="sparkline"></div>
-            </div>
+        <div class="card kpi-card p-3 h-100 text-center">
+            <div class="kpi-title">Deployments</div>
+            <div class="kpi-value">@DataStore.Kpis.DeploymentsToday</div>
+            <div id="sparkDeploys" class="sparkline mx-auto my-2"></div>
             <div class="kpi-caption">Today</div>
         </div>
     </div>
     <div class="col-6 col-md-3">
-        <div class="card kpi-card p-3 h-100">
-            <div class="d-flex justify-content-between">
-                <div>
-                    <div class="kpi-title">MTTR</div>
-                    <div class="kpi-value">@DataStore.Kpis.MttrHours h</div>
-                </div>
-                <div id="sparkMttr" class="sparkline"></div>
-            </div>
+        <div class="card kpi-card p-3 h-100 text-center">
+            <div class="kpi-title">MTTR</div>
+            <div class="kpi-value">@DataStore.Kpis.MttrHours h</div>
+            <div id="sparkMttr" class="sparkline mx-auto my-2"></div>
             <div class="kpi-caption">Hours to restore</div>
         </div>
     </div>
     <div class="col-6 col-md-3">
-        <div class="card kpi-card p-3 h-100">
-            <div class="d-flex justify-content-between">
-                <div>
-                    <div class="kpi-title">Open Violations</div>
-                    <div class="kpi-value">@DataStore.OpenViolations</div>
-                </div>
-                <div id="sparkViol" class="sparkline"></div>
-            </div>
+        <div class="card kpi-card p-3 h-100 text-center">
+            <div class="kpi-title">Open Violations</div>
+            <div class="kpi-value">@DataStore.OpenViolations</div>
+            <div id="sparkViol" class="sparkline mx-auto my-2"></div>
             <div class="kpi-caption">Across all apps</div>
         </div>
     </div>
     <div class="col-6 col-md-3">
-        <div class="card kpi-card p-3 h-100">
-            <div class="d-flex justify-content-between">
-                <div>
-                    <div class="kpi-title">Upcoming</div>
-                    <div class="kpi-value">@DataStore.UpcomingCount</div>
-                </div>
-                <div id="sparkUpcoming" class="sparkline"></div>
-            </div>
+        <div class="card kpi-card p-3 h-100 text-center">
+            <div class="kpi-title">Upcoming</div>
+            <div class="kpi-value">@DataStore.UpcomingCount</div>
+            <div id="sparkUpcoming" class="sparkline mx-auto my-2"></div>
             <div class="kpi-caption">Next 48h</div>
         </div>
     </div>

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -63,20 +63,23 @@ body {
     }
 
 .kpi-title {
-    font-size: .75rem;
+    font-size: .875rem;
     color: var(--ink-600);
     text-transform: uppercase;
+    text-align: center;
 }
 
 .kpi-value {
-    font-size: 1.6rem;
+    font-size: 1.8rem;
     font-weight: 600;
     color: var(--ink-900);
+    text-align: center;
 }
 
 .kpi-caption {
-    font-size: .75rem;
+    font-size: .875rem;
     color: var(--ink-400);
+    text-align: center;
 }
 
 .left-rail {

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -16,6 +16,7 @@
     <script src="https://cdn.amcharts.com/lib/5/xy.js"></script>
     <script src="https://cdn.amcharts.com/lib/5/percent.js"></script>
     <script src="https://cdn.amcharts.com/lib/5/radar.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/gauge.js"></script>
     <script src="https://cdn.amcharts.com/lib/5/themes/Animated.js"></script>
     <!-- Interop helper -->
     <script src="js/amchartsInterop.js"></script>

--- a/wwwroot/js/amchartsInterop.js
+++ b/wwwroot/js/amchartsInterop.js
@@ -244,9 +244,9 @@ window.amchartsInterop = (function () {
     function createViolationsDonut(divId, data) {
         if (!ensureLibs()) return;
         const root = newRoot(divId);
-        root.container.setAll({ layout: root.verticalLayout, paddingTop: 20, paddingRight: 20, paddingBottom: 20, paddingLeft: 20 });
+        root.container.setAll({ paddingTop: 20, paddingRight: 20, paddingBottom: 20, paddingLeft: 20 });
         const chart = root.container.children.push(
-            am5percent.PieChart.new(root, { innerRadius: am5.percent(60) })
+            am5percent.PieChart.new(root, { innerRadius: am5.percent(60), layout: root.verticalLayout, height: am5.percent(100) })
         );
         const series = chart.series.push(
             am5percent.PieSeries.new(root, { valueField: 'count', categoryField: 'type' })
@@ -265,13 +265,14 @@ window.amchartsInterop = (function () {
                 fontWeight: '600'
             })
         );
-        const legend = root.container.children.push(am5.Legend.new(root, {
-            centerX: am5.p50,
-            x: am5.p50,
-            marginTop: 20,
-            layout: root.verticalLayout
-        }));
-        legend.setAll({ width: am5.percent(100) });
+        const legend = chart.children.push(
+            am5.Legend.new(root, {
+                centerX: am5.p50,
+                x: am5.p50,
+                marginTop: 20,
+                layout: root.verticalLayout
+            })
+        );
         legend.labels.template.setAll({ oversizedBehavior: 'wrap', fontSize: 12 });
         legend.data.setAll(series.dataItems);
         series.appear(0, 0);


### PR DESCRIPTION
## Summary
- Load amCharts gauge module to restore gauge speedometers
- Center KPI card content with larger fonts
- Rework violations donut chart to use full space

## Testing
- ⚠️ `dotnet build` *(dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7a9282788323a5ddf2966dc84f1b