### PR TITLE
Fix gauge chart load and improve donut and background

### DIFF
--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -48,7 +48,7 @@ body {
     width: 100%;
     height: 100%;
     overflow: hidden;
-    background: var(--bg-100);
+    background: #e0f2ff;
     border-radius: var(--radius-xl);
 }
 

--- a/wwwroot/js/amchartsInterop.js
+++ b/wwwroot/js/amchartsInterop.js
@@ -63,13 +63,14 @@ window.amchartsInterop = (function () {
 
     function createGauge(divId, value, max) {
         if (!ensureLibs()) return;
-        if (!am5radar || !am5radar.GaugeChart) {
-            console.error("amCharts gauge module not loaded. Check CDN tags in index.html.");
+        if (!am5radar) {
+            console.error("amCharts radar module not loaded. Check CDN tags in index.html.");
             return;
         }
         const root = newRoot(divId);
+        const GaugeClass = am5radar.GaugeChart || am5radar.RadarChart;
         const chart = root.container.children.push(
-            am5radar.GaugeChart.new(root, { startAngle: 180, endAngle: 360 })
+            GaugeClass.new(root, { startAngle: 180, endAngle: 360 })
         );
         const axisRenderer = am5radar.AxisRendererCircular.new(root, { innerRadius: -20 });
         axisRenderer.grid.template.set('visible', false);
@@ -244,10 +245,11 @@ window.amchartsInterop = (function () {
     function createViolationsDonut(divId, data) {
         if (!ensureLibs()) return;
         const root = newRoot(divId);
-        root.container.setAll({ paddingTop: 20, paddingRight: 20, paddingBottom: 20, paddingLeft: 20 });
+        root.container.setAll({ paddingTop: 20, paddingRight: 20, paddingBottom: 20, paddingLeft: 20, layout: root.verticalLayout });
         const chart = root.container.children.push(
-            am5percent.PieChart.new(root, { innerRadius: am5.percent(60), layout: root.verticalLayout, height: am5.percent(100) })
+            am5percent.PieChart.new(root, { innerRadius: am5.percent(60), height: am5.percent(100) })
         );
+        chart.seriesContainer.setAll({ width: am5.percent(80), height: am5.percent(80) });
         const series = chart.series.push(
             am5percent.PieSeries.new(root, { valueField: 'count', categoryField: 'type' })
         );
@@ -265,15 +267,15 @@ window.amchartsInterop = (function () {
                 fontWeight: '600'
             })
         );
-        const legend = chart.children.push(
+        const legend = root.container.children.push(
             am5.Legend.new(root, {
                 centerX: am5.p50,
                 x: am5.p50,
-                marginTop: 20,
+                marginTop: 10,
                 layout: root.verticalLayout
             })
         );
-        legend.labels.template.setAll({ oversizedBehavior: 'wrap', fontSize: 12 });
+        legend.labels.template.setAll({ oversizedBehavior: 'wrap', fontSize: 11 });
         legend.data.setAll(series.dataItems);
         series.appear(0, 0);
         chart.appear(0, 0);


### PR DESCRIPTION
## Summary
- Ensure gauge charts render by falling back to RadarChart when GaugeChart is unavailable
- Resize violations donut to occupy more space and shrink legend font
- Restore light blue background on all chart containers

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68aa86d8a8bc8323baf48dc2ed24774c