### PR TITLE
Fix gauge hand creation in amCharts interop

### DIFF
--- a/wwwroot/js/amchartsInterop.js
+++ b/wwwroot/js/amchartsInterop.js
@@ -87,7 +87,9 @@ window.amchartsInterop = (function () {
             range.get('axisFill').setAll({ visible: true, fillOpacity: 1, fill: am5.color(r.color) });
         });
 
-        const hand = chart.hands.push(am5radar.ClockHand.new(root, { pinRadius: 0, radius: am5.percent(90), bottomWidth: 10 }));
+        const hand = (chart.hands ? chart.hands : chart.children).push(
+            am5radar.ClockHand.new(root, { pinRadius: 0, radius: am5.percent(90), bottomWidth: 10 })
+        );
         hand.axis = xAxis;
         hand.set('value', value);
 


### PR DESCRIPTION
## Summary
- avoid undefined `chart.hands` when creating gauge charts

## Testing
- `dotnet build CicdDashboard.Blazor.sln`


------
https://chatgpt.com/codex/tasks/task_e_68aa8adbf27883238dab078277414a78